### PR TITLE
Document current state and switch to setuptools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# pymp4v2
+
+This repository contains a historical Cython wrapper around the
+[libmp4v2](https://github.com/sergiomb2/libmp4v2) library.  It was
+initially built for Python 2 and last touched over a decade ago.
+
+The code exposes an `MP4File` object implemented in Cython
+(`ext/mp4file.pyx`).  Building the extension requires development
+headers for `libmp4v2` which are not currently installed in this
+environment.
+
+## Current status
+
+* The build uses `setuptools`/Cython.  You must have Cython installed.
+* The library targets Python 2 semantics and has not been updated for
+  Python 3.
+* Tests expect `nose` and Pillow and rely on sample media files which
+  are missing from this repository.
+
+Given the missing dependencies and the age of the code, significant
+work would be required to bring it up to date.  Consider using modern
+alternatives such as [`pymp4`](https://pypi.org/project/pymp4/) or
+[`mutagen`](https://mutagen.readthedocs.io/) for manipulating MP4
+metadata.

--- a/lib/mp4v2/__init__.py
+++ b/lib/mp4v2/__init__.py
@@ -1,0 +1,17 @@
+"""Cython bindings for libmp4v2.
+
+The extension module is built from ``ext/mp4file.pyx`` and exposes an
+``MP4File`` class.  Importing this package will load the compiled
+extension if available.
+"""
+
+from importlib import import_module
+
+try:
+    mp4file = import_module("mp4v2.mp4file")
+except Exception as exc:  # pragma: no cover - extension not built
+    raise ImportError(
+        "The mp4v2 Cython extension is not built or failed to load"
+    ) from exc
+
+__all__ = ["mp4file"]

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,23 @@
-from distutils.core import setup
-from distutils.extension import Extension
-from Cython.Distutils import build_ext
+from setuptools import setup
+from setuptools.extension import Extension
+from Cython.Build import cythonize
 import os, sys
 
 if sys.platform == "darwin":
     # Disable Apple Double files on osx
     os.environ['COPYFILE_DISABLE'] = "true"
 
-ext_modules = [
-    Extension("mp4v2.mp4file", ["ext/mp4file.pyx"],
-    include_dirs = ['/usr/local/include'],
-    library_dirs = ['/usr/local/lib'],
-    libraries    = ['mp4v2'],
-    extra_compile_args = ["-g"],
-    extra_link_args=["-g"],
+ext_modules = cythonize([
+    Extension(
+        "mp4v2.mp4file",
+        ["ext/mp4file.pyx"],
+        include_dirs=["/usr/local/include"],
+        library_dirs=["/usr/local/lib"],
+        libraries=["mp4v2"],
+        extra_compile_args=["-g"],
+        extra_link_args=["-g"],
     )
-]
+])
 
 setup(
     name = "mp4v2",
@@ -24,8 +26,7 @@ setup(
     author="James A. Kyle",
     author_email="jameskyle@ucla.edu",
     url="",
-    cmdclass = {'build_ext': build_ext},
-    ext_modules = ext_modules,
+    ext_modules=ext_modules,
     
     package_dir={'': 'lib'},
     packages =['mp4v2'],


### PR DESCRIPTION
## Summary
- replace the empty README with a short description of the project
- add a basic package initializer
- modernize `setup.py` to use setuptools and cythonize

## Testing
- `python3 setup.py build_ext --inplace` *(fails: mp4v2/mp4v2.h: No such file or directory)*
- `python3 -m nose` *(fails to run due to missing imp module in nose)*

------
https://chatgpt.com/codex/tasks/task_e_684c993a78088324b470db9e178660e6