### PR TITLE
Improve Python code style

### DIFF
--- a/lib/mp4v2/test/test_mp4v2.py
+++ b/lib/mp4v2/test/test_mp4v2.py
@@ -1,30 +1,36 @@
 import unittest
 from nose.tools import raises, assert_equals
-from mp4v2.mp4file import *
-import os, Image
+from mp4v2.mp4file import MP4File
+import os
+from PIL import Image
 from datetime import datetime
+
 
 class TestMP4File(unittest.TestCase):
     def setUp(self):
         data_path = os.path.abspath(os.path.dirname(__file__))
         data_path = os.path.abspath(os.path.join(data_path, "data"))
         test_data = os.path.join(data_path, "Pandora.m4v")
-        
+
         self.mp4 = MP4File(test_data)
-        
+
         # Image contained in the m4v
         self.im = Image.open(os.path.join(data_path, "temp.jpg"))
+
     def test_info(self):
-        expected_info =  'Track\tType\tInfo\n1\tvideo\tH264 High@3.1, 2503.835 secs, 1361 kbps, 960x544 @ 23.976021 fps\n2\taudio\tMPEG-4 AAC LC, 2503.914 secs, 160 kbps, 48000 Hz\n3\taudio\tac-3, 2503.904 secs, 384 kbps, 48000 Hz\n4\ttext\n'
+        expected_info = (
+            "Track\tType\tInfo\n1\tvideo\tH264 High@3.1, 2503.835 secs, 1361 kbps, 960x544 @ 23.976021 fps\n"
+            "2\taudio\tMPEG-4 AAC LC, 2503.914 secs, 160 kbps, 48000 Hz\n"
+            "3\taudio\tac-3, 2503.904 secs, 384 kbps, 48000 Hz\n4\ttext\n"
+        )
         assert_equals(expected_info, self.mp4.info)
-    
+
     @raises(IOError)
     def test_file_not_found(self):
         MP4File('/path/to/some/fake/data.m4v')
 
-    
     def test_attributes(self):
-        
+
         assert_equals(self.mp4.name, None)
         assert_equals(self.mp4.artist, None)
         assert_equals(self.mp4.albumArtist, None)
@@ -45,8 +51,25 @@ class TestMP4File(unittest.TestCase):
         assert_equals(self.mp4.tvEpisodeID, "909")
         assert_equals(self.mp4.tvSeason, 9)
         assert_equals(self.mp4.tvEpisode, 9)
-        assert_equals(self.mp4.description, """Tess kidnaps Lois to find out where Lois went after she disappeared for weeks. Lois's memory of the future depicts a Metropolis under Zod's rule and Clark powerless under the red sun, while Chloe forms a resistance group with Oliver. After learning of these future events, Clark makes an important decision about Zod.""")
-        assert_equals(self.mp4.longDescription, """Smallville is a CW drama that follows the trials and tribulations of a young Clark Kent before he became Superman. Smallville is appropriately set in Smallville, Kansas and weaves in tales like Clark Kent\xe2\x80\x99s discovery of power-giving green rocks, his acquaintance with a young Lex Luthor, and his friendship with Chloe Sullivan and Lana Lang.""")
+        assert_equals(
+            self.mp4.description,
+            (
+                "Tess kidnaps Lois to find out where Lois went after she disappeared for weeks. "
+                "Lois's memory of the future depicts a Metropolis under Zod's rule and Clark powerless "
+                "under the red sun, while Chloe forms a resistance group with Oliver. After learning of "
+                "these future events, Clark makes an important decision about Zod."
+            ),
+        )
+        assert_equals(
+            self.mp4.longDescription,
+            (
+                "Smallville is a CW drama that follows the trials and tribulations of a young Clark "
+                "Kent before he became Superman. Smallville is appropriately set in Smallville, Kansas "
+                "and weaves in tales like Clark Kent\xe2\x80\x99s discovery of power-giving green rocks, "
+                "his acquaintance with a young Lex Luthor, and his friendship with Chloe Sullivan and "
+                "Lana Lang."
+            ),
+        )
         assert_equals(self.mp4.lyrics, None)
         assert_equals(self.mp4.sortName, None)
         assert_equals(self.mp4.sortArtist, None)
@@ -54,10 +77,9 @@ class TestMP4File(unittest.TestCase):
         assert_equals(self.mp4.sortAlbum, None)
         assert_equals(self.mp4.sortComposer, None)
         assert_equals(self.mp4.sortTVShow, None)
-        # Just tests to make sure we get a PIL image type until I can add
-        # out a more accurate test of equivalence. 
+        # Verify that the artwork entry is a Pillow image
         assert_equals(type(self.mp4.artwork[0]), type(self.im))
-        assert_equals(self.mp4.artworkCount, 1) # due to bug in 1.9.1 this is always 1
+        assert_equals(self.mp4.artworkCount, 1)  # due to bug in 1.9.1 this is always 1
         assert_equals(self.mp4.copyright, None)
         assert_equals(self.mp4.encodingTool, 'HandBrake svn2877 2009101201')
         assert_equals(self.mp4.encodedBy, None)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 from setuptools import setup
 from setuptools.extension import Extension
 from Cython.Build import cythonize
-import os, sys
+import os
+import sys
 
 if sys.platform == "darwin":
     # Disable Apple Double files on osx
@@ -20,15 +21,13 @@ ext_modules = cythonize([
 ])
 
 setup(
-    name = "mp4v2",
-    version = "0.1.1",
+    name="mp4v2",
+    version="0.1.1",
     description="A Python interface to libmp4v2",
     author="James A. Kyle",
     author_email="jameskyle@ucla.edu",
     url="",
     ext_modules=ext_modules,
-    
-    package_dir={'': 'lib'},
-    packages =['mp4v2'],
-    
+    package_dir={"": "lib"},
+    packages=["mp4v2"],
 )


### PR DESCRIPTION
## Summary
- clean up setup script syntax
- modernize unit test imports and formatting
- wrap long string literals for readability

## Testing
- `flake8 pymp4v2 --max-line-length=120`
- `python3 -m py_compile setup.py lib/mp4v2/__init__.py lib/mp4v2/test/test_mp4v2.py`
- `nosetests pymp4v2/lib/mp4v2/test/test_mp4v2.py -v` *(fails: ModuleNotFoundError: No module named 'imp')*

------
https://chatgpt.com/codex/tasks/task_e_68519de128dc83249847b4c9a8aa2c29